### PR TITLE
Add api gateway support

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,6 +1,7 @@
 import boto3
 import logging
 import os
+import ast
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -11,6 +12,18 @@ def lambda_handler(event, context):
     arn = os.environ["ARN"]
     msg = "zoomから取得出来たメッセージとか"
     sub = "生徒からのメッセージ"
+    
+    # POSTリクエストでmsgとsubを渡す予定
+    try:
+        body_dict = ast.literal_eval(event['body'])
+    except KeyError:
+        print("Please include body")
+    
+    if 'msg' in body_dict:
+        msg = body_dict['msg']
+
+    if 'sub' in body_dict:
+        sub = body_dict['sub']
 
     #とりあえずメールを送信することを想定
     response = client.publish(TopicArn = arn, Message = msg, Subject = sub)


### PR DESCRIPTION
API Gatewayに対応するためのコードを追記しました。

API Gatewayのメソッドは一旦POSTでいいかなと思っていて、curlコマンド的には以下のようなものをイメージしています。
`curl -X POST -d '{"sub":"foobar", "msg": "hoge"}' https://hogehoge.execute-api.ap-northeast-1.amazonaws.com/dev/message`